### PR TITLE
Dependency bump and remove separate CSS source map file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3610,9 +3610,9 @@
       }
     },
     "postcss": {
-      "version": "7.0.28",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.28.tgz",
-      "integrity": "sha512-YU6nVhyWIsVtlNlnAj1fHTsUKW5qxm3KEgzq2Jj6KTEFOTK8QWR12eIDvrlWhiSTK8WIBFTBhOJV4DY6dUuEbw==",
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.29.tgz",
+      "integrity": "sha512-ba0ApvR3LxGvRMMiUa9n0WR4HjzcYm7tS+ht4/2Nd0NLtHpPIH77fuB9Xh1/yJVz9O/E/95Y/dn8ygWsyffXtw==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
@@ -5357,9 +5357,9 @@
       }
     },
     "svelte": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.22.0.tgz",
-      "integrity": "sha512-v7IUN27pmzmBAhx9AKZoePSlRourpC1ZBR/cgnq99Pd1TY60gvsk+RVTK6ZQfOn1xrAn0ZcqwTCdrnvoeFNQzw==",
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.22.2.tgz",
+      "integrity": "sha512-DxumO0+vvHA6NSc2jtVty08I8lFI43q8P2zX6JxZL8J1kqK5NVjad6TRM/twhnWXC+QScnwkZ15O6X1aTsEKTA==",
       "dev": true
     },
     "svelte-preprocess": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint-config-airbnb-base": "^14.1.0",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-svelte3": "^2.7.3",
-    "postcss": "^7.0.28",
+    "postcss": "^7.0.29",
     "postcss-import": "^12.0.1",
     "postcss-load-config": "^2.1.0",
     "postcss-preset-env": "^6.7.0",
@@ -55,7 +55,7 @@
     "rollup-plugin-svelte": "^5.0.1",
     "rollup-plugin-terser": "^5.3.0",
     "sapper": "^0.27.0",
-    "svelte": "^3.22.0",
+    "svelte": "^3.22.2",
     "svelte-preprocess": "^3.7.4",
     "tailwindcss": "^1.4.4"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -32,7 +32,7 @@ export default {
 					preprocess,
 				],
 				css: (css) => {
-					css.write("static/main.css");
+					css.write("static/main.css", false);
 				},
 			}),
 			resolve({


### PR DESCRIPTION
- [x] CSS source maps where being duplicated. Once in a separate file and also inlined. Changed Rollup config to not produce a separate source map. 
- [x] Minor version bump to Svelte and PostCSS