### PR TITLE
Remove duplication of css

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -31,9 +31,7 @@ export default {
 				preprocess: [
 					preprocess,
 				],
-				css: (css) => {
-					css.write("static/main.css", false);
-				},
+
 			}),
 			resolve({
 				browser: true,
@@ -71,7 +69,7 @@ export default {
 
 	server: {
 		input: config.server.input(),
-		output: config.server.output(),
+		output: { ...config.server.output(), sourcemap: !dev },
 		plugins: [
 			replace({
 				"process.browser": false,

--- a/src/template.html
+++ b/src/template.html
@@ -10,7 +10,6 @@
 		<link rel="manifest" href="manifest.json" />
 		<link rel="icon" type="image/png" href="favicon.png" />
 
-		<link rel="stylesheet" href="/main.css" />
 		<!-- Sapper generates a <style> tag containing critical CSS
   		for the current page. CSS for the rest of the app is
   		lazily loaded when it precaches secondary pages -->
@@ -21,8 +20,8 @@
 		%sapper.head%
 	</head>
 
-	<body class="w-full min-h-screen flex flex-col">
-		<div class="flex-1 flex flex-col" id="sapper">
+	<body class="flex flex-col w-full min-h-screen">
+		<div class="flex flex-col flex-1" id="sapper">
 			%sapper.html%
 		</div>
 


### PR DESCRIPTION
### Remove duplication of CSS
Rollup was writing a `main.css` file into the static folder as well as creating an identical file in the `client` folder in `__sapper__` slash whatever build (dev, static, prod). This file is named something like `main.2951653438.css`, depending on the chunk. By removing `main.css` and all references, CSS source maps do not produce on production. 

- Removed `main.css` from the static folder.
- Removed `main.css` link from the template.
- Removed `css.write()`function from `rollup.config.js`.
- Prod output checks `dev` boolean when producing CSS source maps.

- Relates to [10](https://github.com/babichjacob/sapper-postcss-template/issues/10)
- Fixes [9](https://github.com/babichjacob/sapper-postcss-template/issues/9)